### PR TITLE
Firewall module fix

### DIFF
--- a/modules/firewall/manifests/openport.pp
+++ b/modules/firewall/manifests/openport.pp
@@ -21,7 +21,7 @@ define firewall::openport (
   require firewall
 
   $dports.each |String $dport| {
-    exec { "firewall-cmd-${dport}-{$dproto}":
+    exec { "firewall-cmd-${dport}-${dproto}":
       command => "firewall-cmd --zone=public --add-port=${dport}/${dproto} --permanent",
       path    => "/usr/bin/",
       before  => Exec["firewall-reload${title}"],

--- a/modules/firewall/manifests/openport.pp
+++ b/modules/firewall/manifests/openport.pp
@@ -15,13 +15,14 @@
 # == Define: base::firewall
 #
 define firewall::openport (
-  $dports='',
+  $dports = '',
+  $dproto = 'tcp',
   ) {
   require firewall
 
   $dports.each |String $dport| {
-    exec { "firewall-cmd-${dport}":
-      command => "firewall-cmd --zone=public --add-port=${dport}/tcp --permanent",
+    exec { "firewall-cmd-${dport}-{$dproto}":
+      command => "firewall-cmd --zone=public --add-port=${dport}/${dproto} --permanent",
       path    => "/usr/bin/",
       before  => Exec["firewall-reload${title}"],
     }

--- a/modules/firewall/manifests/openport.pp
+++ b/modules/firewall/manifests/openport.pp
@@ -22,7 +22,7 @@ define firewall::openport (
 
   $dports.each |String $dport| {
     exec { "firewall-cmd-${dport}-${dproto}":
-      command => "firewall-cmd --zone=public --add-port=${dport}/${dproto} --permanent",
+      command => "firewall-cmd --zone=public --add-port=${dport}/$d{proto} --permanent",
       path    => "/usr/bin/",
       before  => Exec["firewall-reload${title}"],
     }

--- a/modules/firewall/manifests/openport.pp
+++ b/modules/firewall/manifests/openport.pp
@@ -22,7 +22,7 @@ define firewall::openport (
 
   $dports.each |String $dport| {
     exec { "firewall-cmd-${dport}-${dproto}":
-      command => "firewall-cmd --zone=public --add-port=${dport}/$d{proto} --permanent",
+      command => "firewall-cmd --zone=public --add-port=${dport}/${dproto} --permanent",
       path    => "/usr/bin/",
       before  => Exec["firewall-reload${title}"],
     }


### PR DESCRIPTION
Ability to work with different protocols was added. 
Parameter 'dproto' has been added & default value 'tcp' was set.
Nothing needs changing in existing modules.