### PR TITLE
Dns node

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -18,8 +18,11 @@ node default {
   # Example:
   #   class { 'my_class': }
 }
-# here is the line 23
+# here is the line 21
 
+node 'dns' {
+  include role::binddns
+}
 
 node 'jenkins.if083' {
   include role::jenkins::master
@@ -34,7 +37,7 @@ node 'zabbix.if083' {
 }
 
 node 'balancer' {
-  $web_serv_name_ip=["web1 192.168.56.161", "web2 192.168.56.162"]
+  $web_serv_name_ip=["web1 192.168.56.161", "web2 192.168.56.162", "web3 192.168.56.163"]
   include haproxy
 }
 
@@ -44,7 +47,6 @@ node 'db.if083' {
 node 'dbslave.if083' {
   include role::slave
 }
-
 
 node /^web/ {
   include role::webapp

--- a/modules/binddns/Gemfile
+++ b/modules/binddns/Gemfile
@@ -1,0 +1,18 @@
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['>= 3.3']
+gem 'metadata-json-lint'
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 1.2.0'
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+  gem 'rake', '~> 10.0'
+else
+  # rubocop requires ruby >= 1.9
+  gem 'rubocop'
+end

--- a/modules/binddns/README.md
+++ b/modules/binddns/README.md
@@ -1,0 +1,89 @@
+# binddns
+
+#### Table of Contents
+
+1. [Description](#description)
+1. [Setup - The basics of getting started with binddns](#setup)
+    * [What binddns affects](#what-binddns-affects)
+    * [Setup requirements](#setup-requirements)
+    * [Beginning with binddns](#beginning-with-binddns)
+1. [Usage - Configuration options and additional functionality](#usage)
+1. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+1. [Limitations - OS compatibility, etc.](#limitations)
+1. [Development - Guide for contributing to the module](#development)
+
+## Description
+
+Start with a one- or two-sentence summary of what the module does and/or what
+problem it solves. This is your 30-second elevator pitch for your module.
+Consider including OS/Puppet version it works with.
+
+You can give more descriptive information in a second paragraph. This paragraph
+should answer the questions: "What does this module *do*?" and "Why would I use
+it?" If your module has a range of functionality (installation, configuration,
+management, etc.), this is the time to mention it.
+
+## Setup
+
+### What binddns affects **OPTIONAL**
+
+If it's obvious what your module touches, you can skip this section. For
+example, folks can probably figure out that your mysql_instance module affects
+their MySQL instances.
+
+If there's more that they should know about, though, this is the place to mention:
+
+* A list of files, packages, services, or operations that the module will alter,
+  impact, or execute.
+* Dependencies that your module automatically installs.
+* Warnings or other important notices.
+
+### Setup Requirements **OPTIONAL**
+
+If your module requires anything extra before setting up (pluginsync enabled,
+etc.), mention it here.
+
+If your most recent release breaks compatibility or requires particular steps
+for upgrading, you might want to include an additional "Upgrading" section
+here.
+
+### Beginning with binddns
+
+The very basic steps needed for a user to get the module up and running. This
+can include setup steps, if necessary, or it can be an example of the most
+basic use of the module.
+
+## Usage
+
+This section is where you describe how to customize, configure, and do the
+fancy stuff with your module here. It's especially helpful if you include usage
+examples and code samples for doing things with your module.
+
+## Reference
+
+Users need a complete list of your module's classes, types, defined types providers, facts, and functions, along with the parameters for each. You can provide this list either via Puppet Strings code comments or as a complete list in this Reference section.
+
+* If you are using Puppet Strings code comments, this Reference section should include Strings information so that your users know how to access your documentation.
+
+* If you are not using Puppet Strings, include a list of all of your classes, defined types, and so on, along with their parameters. Each element in this listing should include:
+
+  * The data type, if applicable.
+  * A description of what the element does.
+  * Valid values, if the data type doesn't make it obvious.
+  * Default value, if any.
+
+## Limitations
+
+This is where you list OS compatibility, version compatibility, etc. If there
+are Known Issues, you might want to include them under their own heading here.
+
+## Development
+
+Since your module is awesome, other users will want to play with it. Let them
+know what the ground rules for contributing are.
+
+## Release Notes/Contributors/Etc. **Optional**
+
+If you aren't using changelog, put your release notes here (though you should
+consider using changelog). You can also add any additional sections you feel
+are necessary or important to include here. Please use the `## ` header.

--- a/modules/binddns/Rakefile
+++ b/modules/binddns/Rakefile
@@ -1,0 +1,32 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'metadata-json-lint/rake_task'
+
+if RUBY_VERSION >= '1.9'
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+end
+
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.relative = true
+PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']
+
+desc 'Validate manifests, templates, and ruby files'
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb', 'lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ %r{spec/fixtures}
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end
+
+desc 'Run lint, validate, and spec tests.'
+task :test do
+  [:lint, :validate, :spec].each do |test|
+    Rake::Task[test].invoke
+  end
+end

--- a/modules/binddns/manifests/init.pp
+++ b/modules/binddns/manifests/init.pp
@@ -1,0 +1,74 @@
+# Class: binddns
+# ===========================
+#  This module uses yet for RedHat family OS only
+# Copyright
+# ---------
+#
+# Copyright 2018 oleksdiam
+#
+class binddns (
+  $ensure        = 'installed',
+  $ip_pool       = '192.168.56',
+  $ip_mask       = '0/24',
+  $reverse_pool  = '56.168.192',
+  $dnsservername = 'dns',
+  $domainname    = 'if083',
+  $masterslave   = 'master',
+  $dnsserverip   = '2',
+){
+  
+  case $::osfamily {
+    'RedHat', 'Linux': {}
+    default: {fail("Unsupported OS: ${::osfamily}.  Implement me?")}
+  }
+
+  package { 'bind':
+    ensure => $ensure,
+  }
+  package { 'bind-utils':
+    ensure => $ensure,
+  }
+
+  file { "/var/log/named":
+    ensure => directory,
+    mode   => '0660',
+    owner  => 'named',
+    group  => 'named',
+  }
+  ->
+  file { "/var/log/named/default.log":
+    ensure => file,
+    mode   => '0660',
+    owner  => 'named',
+    group  => 'named',
+  }
+
+  file { "/etc/named.conf":
+    ensure => file,
+    mode   => '0644',
+    content => template('binddns/named.conf.erb'),
+    notify  => Service['named'],
+  }
+
+  file { "/var/named/fwd.${domainname}.db":
+    ensure => file,
+    mode   => '0644',
+    content => template('binddns/fwd.db.erb'),
+    notify  => Service['named'],
+  }
+  file { "/var/named/${reverse_pool}.db":
+    ensure => file,
+    mode   => '0644',
+    content => template('binddns/reverse.db.erb'),
+    notify  => Service['named'],
+  }
+
+  service { 'named':
+    enable      => true,
+    ensure      => running,
+    hasrestart  => true,
+    hasstatus   => true,
+  }
+}
+
+

--- a/modules/binddns/metadata.json
+++ b/modules/binddns/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "oleksdiam-binddns",
+  "version": "0.1.0",
+  "author": "dias",
+  "summary": "bind dns server install module",
+  "license": "Apache-2.0",
+  "source": "",
+  "project_page": null,
+  "issues_url": null,
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 1.0.0"
+    }
+  ],
+  "data_provider": null
+}
+

--- a/modules/binddns/templates/fwd.db.erb
+++ b/modules/binddns/templates/fwd.db.erb
@@ -1,0 +1,29 @@
+$TTL 86400
+@   IN  SOA     <%= @dnsservername %>.<%= @domainname %>. root.<%= @domainname %>. (
+3           ;Serial
+3600        ;Refresh
+1800        ;Retry
+604800      ;Expire
+86400       ;Minimum TTL
+)
+;Name Server Information
+         IN  NS      <%= @dnsservername %>.<%= @domainname %>.
+;IP address of Name Server
+<%= @dnsservername %>.<%= @domainname %>. IN  A       <%= @ip_pool %>.<%= @dnsserverip %>
+;A - Record HostName To Ip Address
+pmaster   IN  A       <%= @ip_pool %>.10
+rsyslog   IN  A       <%= @ip_pool %>.15
+db        IN  A       <%= @ip_pool %>.150
+dbslave   IN  A       <%= @ip_pool %>.151
+balancer  IN  A       <%= @ip_pool %>.160
+web1      IN  A       <%= @ip_pool %>.161
+web2      IN  A       <%= @ip_pool %>.162
+web3      IN  A       <%= @ip_pool %>.163
+jenkins   IN  A       <%= @ip_pool %>.170
+sonar     IN  A       <%= @ip_pool %>.180
+gitlab    IN  A       <%= @ip_pool %>.190
+repo      IN  A       <%= @ip_pool %>.191
+zabbix    IN  A       <%= @ip_pool %>.200
+
+;Mail exchanger
+;<%= @domainname %>. IN  MX 10   mail.<%= @domainname %>.

--- a/modules/binddns/templates/named.conf.erb
+++ b/modules/binddns/templates/named.conf.erb
@@ -1,0 +1,77 @@
+//
+// named.conf
+//
+// Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
+// server as a caching only nameserver (as a localhost DNS resolver only).
+//
+// See /usr/share/doc/bind*/sample/ for example named configuration files.
+//
+// See the BIND Administrator's Reference Manual (ARM) for details about the
+// configuration located in /usr/share/doc/bind-{version}/Bv9ARM.html
+
+options {
+	listen-on port 53 { 127.0.0.1;<%= @ip_pool %>.<%= @ip_mask %>; };
+    listen-on-v6 port 53 { none; };
+    directory   "/var/named";
+    dump-file   "/var/named/data/cache_dump.db";
+    statistics-file "/var/named/data/named_stats.txt";
+    memstatistics-file "/var/named/data/named_mem_stats.txt";
+    allow-query  { localhost;<%= @ip_pool %>.<%= @ip_mask %>; };
+
+	/* 
+     - If you are building an AUTHORITATIVE DNS server, do NOT enable recursion.
+     - If you are building a RECURSIVE (caching) DNS server, you need to enable 
+       recursion. 
+     - If your recursive DNS server has a public IP address, you MUST enable access 
+       control to limit queries to your legitimate users. Failing to do so will
+       cause your server to become part of large scale DNS amplification 
+       attacks. Implementing BCP38 within your network would greatly
+       reduce such attack surface 
+    */
+    recursion no;
+//  recursion yes;
+//  allow-recursion     { localhost;<%= @ip_pool %>.<%= @ip_mask %>; };
+//  forwarders          { 8.8.8.8; }
+    dnssec-enable no;
+    dnssec-validation no;
+    querylog yes;
+
+    /* Path to ISC DLV key */
+    bindkeys-file "/etc/named.iscdlv.key";
+
+    managed-keys-directory "/var/named/dynamic";
+
+    pid-file "/run/named/named.pid";
+    session-keyfile "/run/named/session.key";
+};
+
+logging {
+    channel default {
+      file "/var/log/named/default.log" versions 5 size 5m;
+      severity dynamic;
+      print-time yes;
+    };
+    channel "query" {
+      file "/var/log/named/query.log" versions 5 size 5m;
+      print-time yes;
+      print-severity no;
+      print-category no;
+    };
+    category default { default; };
+    category queries { query;   };
+};
+
+zone "<%= @domainname %>" IN {
+    type <%= @masterslave %>;
+    file "fwd.<%= @domainname %>.db";
+    allow-update { none; };
+};
+
+zone "<%= @reverse_pool%>.in-addr.arpa" IN {
+    type <%= @masterslave %>;
+    file "<%= @reverse_pool%>.db";
+    allow-update { none; };
+};
+
+include "/etc/named.rfc1912.zones";
+include "/etc/named.root.key";

--- a/modules/binddns/templates/reverse.db.erb
+++ b/modules/binddns/templates/reverse.db.erb
@@ -1,0 +1,26 @@
+$TTL 86400
+@   IN  SOA     <%= @dnsservername %>.<%= @domainname %>. root.<%= @domainname %>. (
+3           ;Serial
+3600        ;Refresh
+1800        ;Retry
+604800      ;Expire
+86400       ;Minimum TTL
+)
+;Name Server Information
+  IN  NS      <%= @dnsservername %>.<%= @domainname %>.
+;Reverse lookup for Name Server
+<%= @dnsserverip %>        IN  PTR     <%= @dnsservername %>.<%= @domainname %>.
+;PTR Record IP address to HostName
+10       IN  PTR     pmaster.<%= @domainname %>.
+15       IN  PTR     rsyslog.<%= @domainname %>.
+150      IN  PTR     db.<%= @domainname %>.
+151      IN  PTR     dbslave.<%= @domainname %>.
+160      IN  PTR     balancer.<%= @domainname %>.
+161      IN  PTR     web1.<%= @domainname %>.
+162      IN  PTR     web2.<%= @domainname %>.
+163      IN  PTR     web3.<%= @domainname %>.
+170      IN  PTR     jenkins.<%= @domainname %>.
+180      IN  PTR     sonar.<%= @domainname %>.
+190      IN  PTR     gitlab.<%= @domainname %>.
+191      IN  PTR     repo.<%= @domainname %>.
+200      IN  PTR     zabbix.<%= @domainname %>.

--- a/modules/profile/manifests/binddns.pp
+++ b/modules/profile/manifests/binddns.pp
@@ -1,0 +1,26 @@
+class profile::binddns {
+  
+  $dports        = ['53']
+
+  class { 'binddns':
+  }
+
+  class {'rsyslog::client':
+  }
+
+  rsyslog::config {'binddns':
+    log_name => '/var/log/named/*',
+    log_tag  => 'bind_',
+    app_name => 'bind',
+    severity => 'info',
+  }
+
+  firewall::openport {'tcpdns':
+    dports       => $dports,
+    dproto       => 'tcp',
+  }
+  firewall::openport {'udpdns':
+    dports       => $dports,
+    dproto       => 'udp',
+  }
+}

--- a/modules/role/manifests/binddns.pp
+++ b/modules/role/manifests/binddns.pp
@@ -1,0 +1,5 @@
+class role::binddns {
+  include profile::basenode
+  include profile::binddns
+
+}


### PR DESCRIPTION
Here is the node with a DNS server.
forward & reverse zones are configured.
Splitted general & queries logging .
In additional, were changed provisioner scripts to patch & avoid rewriting resolv.conf during network restart (not in the pull request).
Script, added into provision file:
sed -i '/plugins=/ a dns=none' /etc/NetworkManager/NetworkManager.conf
systemctl restart NetworkManager
sed -i "/search/ a nameserver ${DNS_IP}" /etc/resolv.conf
systemctl restart network