### PR TITLE
lists of nodes for dns zones extracted to external templates

### DIFF
--- a/modules/binddns/templates/fwd.db.erb
+++ b/modules/binddns/templates/fwd.db.erb
@@ -11,19 +11,6 @@ $TTL 86400
 ;IP address of Name Server
 <%= @dnsservername %>.<%= @domainname %>. IN  A       <%= @ip_pool %>.<%= @dnsserverip %>
 ;A - Record HostName To Ip Address
-pmaster   IN  A       <%= @ip_pool %>.10
-rsyslog   IN  A       <%= @ip_pool %>.15
-db        IN  A       <%= @ip_pool %>.150
-dbslave   IN  A       <%= @ip_pool %>.151
-balancer  IN  A       <%= @ip_pool %>.160
-web1      IN  A       <%= @ip_pool %>.161
-web2      IN  A       <%= @ip_pool %>.162
-web3      IN  A       <%= @ip_pool %>.163
-jenkins   IN  A       <%= @ip_pool %>.170
-sonar     IN  A       <%= @ip_pool %>.180
-gitlab    IN  A       <%= @ip_pool %>.190
-repo      IN  A       <%= @ip_pool %>.191
-zabbix    IN  A       <%= @ip_pool %>.200
-
+<%= scope.call_function('template', ["profile/fwd_zone_list.erb"]) %>
 ;Mail exchanger
 ;<%= @domainname %>. IN  MX 10   mail.<%= @domainname %>.

--- a/modules/binddns/templates/reverse.db.erb
+++ b/modules/binddns/templates/reverse.db.erb
@@ -11,16 +11,4 @@ $TTL 86400
 ;Reverse lookup for Name Server
 <%= @dnsserverip %>        IN  PTR     <%= @dnsservername %>.<%= @domainname %>.
 ;PTR Record IP address to HostName
-10       IN  PTR     pmaster.<%= @domainname %>.
-15       IN  PTR     rsyslog.<%= @domainname %>.
-150      IN  PTR     db.<%= @domainname %>.
-151      IN  PTR     dbslave.<%= @domainname %>.
-160      IN  PTR     balancer.<%= @domainname %>.
-161      IN  PTR     web1.<%= @domainname %>.
-162      IN  PTR     web2.<%= @domainname %>.
-163      IN  PTR     web3.<%= @domainname %>.
-170      IN  PTR     jenkins.<%= @domainname %>.
-180      IN  PTR     sonar.<%= @domainname %>.
-190      IN  PTR     gitlab.<%= @domainname %>.
-191      IN  PTR     repo.<%= @domainname %>.
-200      IN  PTR     zabbix.<%= @domainname %>.
+<%= scope.call_function('template', ["profile/rev_zone_list.erb"]) %>

--- a/modules/profile/templates/fwd_zone_list.erb
+++ b/modules/profile/templates/fwd_zone_list.erb
@@ -1,0 +1,13 @@
+pmaster   IN  A       <%= @ip_pool %>.10
+rsyslog   IN  A       <%= @ip_pool %>.15
+db        IN  A       <%= @ip_pool %>.150
+dbslave   IN  A       <%= @ip_pool %>.151
+balancer  IN  A       <%= @ip_pool %>.160
+web1      IN  A       <%= @ip_pool %>.161
+web2      IN  A       <%= @ip_pool %>.162
+web3      IN  A       <%= @ip_pool %>.163
+jenkins   IN  A       <%= @ip_pool %>.170
+sonar     IN  A       <%= @ip_pool %>.180
+gitlab    IN  A       <%= @ip_pool %>.190
+repo      IN  A       <%= @ip_pool %>.191
+zabbix    IN  A       <%= @ip_pool %>.200

--- a/modules/profile/templates/rev_zone_list.erb
+++ b/modules/profile/templates/rev_zone_list.erb
@@ -1,0 +1,13 @@
+10       IN  PTR     pmaster.<%= @domainname %>.
+15       IN  PTR     rsyslog.<%= @domainname %>.
+150      IN  PTR     db.<%= @domainname %>.
+151      IN  PTR     dbslave.<%= @domainname %>.
+160      IN  PTR     balancer.<%= @domainname %>.
+161      IN  PTR     web1.<%= @domainname %>.
+162      IN  PTR     web2.<%= @domainname %>.
+163      IN  PTR     web3.<%= @domainname %>.
+170      IN  PTR     jenkins.<%= @domainname %>.
+180      IN  PTR     sonar.<%= @domainname %>.
+190      IN  PTR     gitlab.<%= @domainname %>.
+191      IN  PTR     repo.<%= @domainname %>.
+200      IN  PTR     zabbix.<%= @domainname %>.


### PR DESCRIPTION
The DNS server's code updated. The lists of nodes provided by DNS server were moved from  zone file's templates to external templates, placed in /profile/templates. Thus I avoid hardcoding in the dns server module. 
With minor changes in code, it's possible to use regular files with nodes list instead templates too, 
